### PR TITLE
make it possible to use python & perl plugins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ MAINTAINER Levi Smith <levi@fynx.me>
 RUN apk add --update\
     weechat\
     python\
+    weechat-python\
+    weechat-perl\
     bash\
     && rm -rf /var/cache/apk/*
 

--- a/edge/Dockerfile
+++ b/edge/Dockerfile
@@ -4,6 +4,8 @@ MAINTAINER Levi Smith <levi@fynx.me>
 RUN apk add --update\
     weechat\
     python\
+    weechat-python\
+    weechat-perl\
     bash\
     && rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
if you run /python or /perl in the dockerized weechat, the packages are missing. 

This PR adds them.